### PR TITLE
Change how collapsible builder updates

### DIFF
--- a/src/lib/builders/collapsible/index.ts
+++ b/src/lib/builders/collapsible/index.ts
@@ -7,24 +7,24 @@ type CreateCollapsibleArgs = {
 } & CollapsibleRootProps;
 
 export type CollapsibleRootProps = {
-    open?: boolean;
-    disabled?: boolean;
+	open?: boolean;
+	disabled?: boolean;
 };
 
 type CollapsibleProps = Required<CollapsibleRootProps>; // Add subcomponent props
 
 export function createCollapsible(args?: CreateCollapsibleArgs) {
-
-    const ctx: WritableObject<CollapsibleProps> = {
-        open: writable(args?.open),
-        disabled: writable(args?.disabled)
-    };
+	const ctx: WritableObject<CollapsibleProps> = {
+		open: writable(args?.open),
+		disabled: writable(args?.disabled),
+	};
 
 	ctx.open.subscribe((open) => {
+		if (typeof open === 'undefined') return;
 		args?.onChange?.(open);
 	});
 
-    const root = derived([ctx.open, ctx.disabled], ([$open, $disabled]) => ({
+	const root = derived([ctx.open, ctx.disabled], ([$open, $disabled]) => ({
 		'data-state': $open ? 'open' : 'closed',
 		'data-disabled': $disabled ? 'true' : 'undefined',
 	}));
@@ -46,7 +46,7 @@ export function createCollapsible(args?: CreateCollapsibleArgs) {
 		hidden: $open ? undefined : true,
 	}));
 
-    return Object.assign(contextUpdater(ctx), {
+	return Object.assign(contextUpdater(ctx), {
 		root,
 		trigger,
 		content,

--- a/src/lib/components/Collapsible/content.svelte
+++ b/src/lib/components/Collapsible/content.svelte
@@ -31,7 +31,7 @@
 	})();
 
 	const ctx = getCollapsibleRootContext();
-	$: ({ content, open } = $ctx);
+	const { content, open } = ctx;
 </script>
 
 {#if asChild}

--- a/src/lib/components/Collapsible/root.svelte
+++ b/src/lib/components/Collapsible/root.svelte
@@ -1,16 +1,10 @@
 <script lang="ts" context="module">
-	import { createCollapsible } from '$lib/builders';
+	import { createCollapsible, type CollapsibleRootProps } from '$lib/builders';
 	import { uniqueContext } from '$lib/internal/helpers';
-
-	export type CollapsibleRootProps = BaseProps & {
-		open?: boolean;
-		disabled?: boolean;
-		asChild?: boolean;
-	};
 
 	type CollapsibleRootContext = ReturnType<typeof createCollapsible>;
 
-	const { getContext, setContext } = uniqueContext<Readable<CollapsibleRootContext>>();
+	const { getContext, setContext } = uniqueContext<CollapsibleRootContext>();
 	export const getCollapsibleRootContext = getContext;
 </script>
 
@@ -18,9 +12,9 @@
 	import { useActions } from '$lib/internal/helpers/useActions';
 	import type { BaseProps } from '$lib/internal/types';
 	import { createEventDispatcher } from 'svelte';
-	import { writable, type Readable } from 'svelte/store';
+	// import { writable, type Readable } from 'svelte/store';
 
-	type $$Props = CollapsibleRootProps;
+	type $$Props = CollapsibleRootProps & BaseProps & { asChild: boolean };
 	export let open: $$Props['open'] = false;
 	export let disabled: $$Props['disabled'] = false;
 	export let use: $$Props['use'] = [];
@@ -30,19 +24,20 @@
 		change: boolean;
 	}>();
 
-	const collapsible = writable(null as unknown as CollapsibleRootContext);
-	$: $collapsible = createCollapsible({
-		open,
+	const collapsible = createCollapsible({
 		onChange: (v) => {
 			open = v;
 			dispatch('change', v);
-		},
-		disabled,
+		}
 	});
 
 	setContext(collapsible);
 
-	$: root = $collapsible.root;
+    $: collapsible({
+        open, disabled
+    });
+
+	const root = collapsible.root;
 </script>
 
 {#if asChild}

--- a/src/lib/components/Collapsible/root.svelte
+++ b/src/lib/components/Collapsible/root.svelte
@@ -14,7 +14,7 @@
 	import { createEventDispatcher } from 'svelte';
 	// import { writable, type Readable } from 'svelte/store';
 
-	type $$Props = CollapsibleRootProps & BaseProps & { asChild: boolean };
+	type $$Props = CollapsibleRootProps & BaseProps & { asChild?: boolean };
 	export let open: $$Props['open'] = false;
 	export let disabled: $$Props['disabled'] = false;
 	export let use: $$Props['use'] = [];
@@ -28,14 +28,15 @@
 		onChange: (v) => {
 			open = v;
 			dispatch('change', v);
-		}
+		},
 	});
 
 	setContext(collapsible);
 
-    $: collapsible({
-        open, disabled
-    });
+	$: collapsible({
+		open,
+		disabled,
+	});
 
 	const root = collapsible.root;
 </script>

--- a/src/lib/components/Collapsible/trigger.svelte
+++ b/src/lib/components/Collapsible/trigger.svelte
@@ -14,7 +14,7 @@
 	export let asChild: $$Props['asChild'] = false;
 
 	const ctx = getCollapsibleRootContext();
-	$: trigger = $ctx?.trigger ?? {};
+	const trigger = ctx?.trigger ?? {};
 </script>
 
 {#if asChild}

--- a/src/lib/internal/stores/derived.ts
+++ b/src/lib/internal/stores/derived.ts
@@ -1,5 +1,5 @@
 import { tick } from 'svelte';
-import { derived, get, type Readable } from 'svelte/store';
+import { derived, type Readable } from 'svelte/store';
 import { getElementById, isBrowser, uuid } from '../helpers';
 import type { WritableObject } from '../types';
 
@@ -37,13 +37,11 @@ type Attach = <T extends keyof HTMLElementEventMap>(
 	options?: boolean | AddEventListenerOptions
 ) => void;
 
-
-
 export function elementDerived<S extends Stores, T>(
 	stores: S,
 	fn: (values: StoresValues<S>, attach: Attach) => T
 ) {
-    const id = uuid();
+	const id = uuid();
 	let unsubscribers: (() => void)[] = [];
 	const attach: Attach = (event, listener, options) => {
 		if (isBrowser) {
@@ -63,9 +61,9 @@ export function elementDerived<S extends Stores, T>(
 		unsubscribers.forEach((fn) => fn());
 		unsubscribers = [];
 		return {
-            ...fn($storeValues, attach), 
-            'data-radix-id': id
-        };
+			...fn($storeValues, attach),
+			'data-radix-id': id,
+		};
 	});
 
 	return {
@@ -80,14 +78,13 @@ export function elementDerived<S extends Stores, T>(
 	};
 }
 
-
 export function contextUpdater<T>(ctx: WritableObject<T>) {
-    return (newContext: Partial<T>) => {
-        for (const key in newContext) {
-            const prop = newContext[key as keyof T];
-            if (typeof prop !== 'undefined') {
-                ctx[key as keyof T].set(prop);
-            }
-        }
-    }
+	return (newContext: Partial<T>) => {
+		for (const key in newContext) {
+			const prop = newContext[key as keyof T];
+			if (typeof prop !== 'undefined') {
+				ctx[key as keyof T].set(prop);
+			}
+		}
+	};
 }

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -45,5 +45,4 @@ export type BaseProps<El extends keyof SvelteHTMLElements = 'div'> = SvelteHTMLE
 	[key: `data-${string}`]: string | boolean | undefined;
 };
 
-
-export type WritableObject<T> = {[Property in keyof T]: Writable<T[Property]>}
+export type WritableObject<T> = { [Property in keyof T]: Writable<T[Property]> };

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -1,3 +1,4 @@
+import type { Writable } from 'svelte/store';
 import type { ActionArray } from './helpers';
 import type { SvelteHTMLElements } from 'svelte/elements';
 
@@ -43,3 +44,6 @@ export type BaseProps<El extends keyof SvelteHTMLElements = 'div'> = SvelteHTMLE
 	['data-state']?: string;
 	[key: `data-${string}`]: string | boolean | undefined;
 };
+
+
+export type WritableObject<T> = {[Property in keyof T]: Writable<T[Property]>}


### PR DESCRIPTION
Changed the collapsible builder to be called only at the component initialization and update using the context updater method.

+ Moved element id generation from the component builder to the elementDerived method, so that it is generated and used automatically.