### PR TITLE
fix: Fixes the `typesVersions` map to fix incorrect auto-import paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"typesVersions": {
 		">4.0": {
-			"index": [
+			"index.d.ts": [
 				"./dist/index.d.ts"
 			],
 			"internal/*": [


### PR DESCRIPTION
Fixes the same auto-import path issue as mentioned in Melt UI: https://github.com/melt-ui/melt-ui/pull/56